### PR TITLE
Feat: 홈화면 카드, 적금 컴포넌트 생성

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,10 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-<<<<<<< HEAD
-
-=======
->>>>>>> d79155c (Feat: 홈 군인 프로필 shadcn 사용하여 바 구현)
 @custom-variant dark (&:is(.dark *));
 
 @theme {

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,10 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> d79155c (Feat: 홈 군인 프로필 shadcn 사용하여 바 구현)
 @custom-variant dark (&:is(.dark *));
 
 @theme {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,5 @@
 import Profile from "@/components/home/Profile";
 
 export default function Page() {
-  return (
-    <>
-      <Profile endDate={""} />
-    </>
-  );
+  return <>홈</>;
 }

--- a/components/home/Card.tsx
+++ b/components/home/Card.tsx
@@ -36,7 +36,6 @@ export default function Card() {
             align="center"
             padding="py-0"
             onClick={handleClick}
-            className="flex items-center justify-center h-[23px]"
           />
         </div>
       </div>

--- a/components/home/Card.tsx
+++ b/components/home/Card.tsx
@@ -26,7 +26,7 @@ export default function Card() {
           123,000원
         </Txt>
 
-        <div className="mt-5 w-[80px]">
+        <div className="mt-3">
           <PrimaryButton
             title="보내기"
             color="green"
@@ -35,6 +35,7 @@ export default function Card() {
             weight="medium"
             align="center"
             padding="py-0"
+            className="w-[80px] h-[23px]"
             onClick={handleClick}
           />
         </div>

--- a/components/home/Card.tsx
+++ b/components/home/Card.tsx
@@ -1,3 +1,56 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import Txt from "@/components/atoms/Text";
+import PrimaryButton from "../atoms/PrimaryButton";
+
 export default function Card() {
-  return <>하나 나라사랑카드</>;
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push("/splash");
+  };
+
+  return (
+    <div className="flex items-center justify-between px-6 py-3 bg-green-5f2 border-[1px] border-green-9e7  rounded-[20px] w-max h-[150px] overflow-hidden gap-3">
+      {/* 카드 정보 */}
+      <div className="flex flex-col items-start">
+        <Txt size={16} weight="bold" className="text-gray-353">
+          하나 나라사랑카드(체크)
+        </Txt>
+        <Txt size={12} weight="bold" className="text-blue-9a0">
+          입출금 424-912949-15293
+        </Txt>
+        <Txt size={16} weight="bold" className="text-gray-900">
+          123,000원
+        </Txt>
+
+        <div className="mt-5 w-[80px]">
+          <PrimaryButton
+            title="보내기"
+            color="green"
+            rounded="sm"
+            textSize={12}
+            weight="medium"
+            align="center"
+            padding="py-0"
+            onClick={handleClick}
+            className="flex items-center justify-center h-[23px]"
+          />
+        </div>
+      </div>
+
+      {/* 카드 이미지 */}
+      <div className="flex-shrink-0 relative w-[80px] h-[130px] ml-9">
+        <Image
+          src="/images/ic-hanacard.svg"
+          alt="하나 나라사랑카드"
+          fill
+          className="object-contain"
+          priority
+        />
+      </div>
+    </div>
+  );
 }

--- a/components/home/Savings.tsx
+++ b/components/home/Savings.tsx
@@ -1,3 +1,69 @@
+"use client";
+
+import Image from "next/image";
+import Txt from "@/components/atoms/Text";
+
 export default function Savings() {
-  return <>하나 장병내일준비 적금</>;
+  return (
+    <div
+      className="flex flex-col justify-between px-6 py-4 bg-white-fff rounded-[20px] w-max h-[153px] shadow-sm"
+      style={{ boxShadow: "0px 0px 5px 0px rgba(0, 0, 0, 0.15)" }}
+    >
+      {/* 적금 제목, 금액, 이미지 */}
+      <div className="flex justify-between w-full">
+        <div className="flex flex-col items-start gap-1">
+          <Txt size={16} weight="bold" className="text-gray-939">
+            하나 장병내일준비 적금
+          </Txt>
+          <Txt size={16} weight="bold" className="text-gray-939">
+            2,109,762원
+          </Txt>
+        </div>
+        <div className="flex-shrink-0 relative w-[80px] h-[60px] ml-15">
+          <Image
+            src="/images/ic-bankbook.svg"
+            alt="적금 통장"
+            fill
+            className="object-contain"
+            priority
+          />
+        </div>
+      </div>
+
+      {/* 조건 달성 여부 */}
+      <div className="flex flex-col gap-1 mt-2 w-full">
+        <div className="flex items-center w-full">
+          <div className="flex items-center justify-center w-[50px] h-[20px] bg-green-49d rounded-[10px] mr-2">
+            <Txt size={12} weight="medium" className="text-white-2f2">
+              달성
+            </Txt>
+          </div>
+          <Txt size={12} weight="medium" className="text-gray-939">
+            주택청약종합저축
+          </Txt>
+          <div className="ml-auto">
+            <Txt size={10} weight="medium" className="text-gray-939">
+              연 0.50%
+            </Txt>
+          </div>
+        </div>
+
+        <div className="flex items-center w-full">
+          <div className="flex items-center justify-center w-[50px] h-[20px] bg-white-2f2 rounded-[10px] mr-2">
+            <Txt size={12} weight="medium" className="text-green-49d">
+              미달성
+            </Txt>
+          </div>
+          <Txt size={12} weight="medium" className="text-gray-939">
+            하나카드결제
+          </Txt>
+          <div className="ml-auto">
+            <Txt size={10} weight="medium" className="text-gray-939">
+              연 0.70%
+            </Txt>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/components/home/Savings.tsx
+++ b/components/home/Savings.tsx
@@ -3,10 +3,14 @@
 import Image from "next/image";
 import Txt from "@/components/atoms/Text";
 
-export default function Savings() {
+type Props = {
+  savingBalance: number;
+};
+
+export default function Savings({ savingBalance }: Props) {
   return (
     <div
-      className="flex flex-col justify-between px-6 py-4 bg-white-fff rounded-[20px] w-max h-[153px] shadow-sm"
+      className="flex flex-col justify-between px-6 py-4 bg-white-fff rounded-[20px] w-max h-[153px]"
       style={{ boxShadow: "0px 0px 5px 0px rgba(0, 0, 0, 0.15)" }}
     >
       {/* 적금 제목, 금액, 이미지 */}
@@ -16,10 +20,10 @@ export default function Savings() {
             하나 장병내일준비 적금
           </Txt>
           <Txt size={16} weight="bold" className="text-gray-939">
-            2,109,762원
+            {savingBalance.toLocaleString()}원
           </Txt>
         </div>
-        <div className="flex-shrink-0 relative w-[80px] h-[60px] ml-15">
+        <div className="flex-shrink-0 relative w-[80px] h-[60px] ml-[57px]">
           <Image
             src="/images/ic-bankbook.svg"
             alt="적금 통장"

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -2,16 +2,15 @@
 
 import * as ProgressPrimitive from "@radix-ui/react-progress";
 import * as React from "react";
+import { ComponentPropsWithoutRef, forwardRef, ElementRef } from "react";
 import { cn } from "@/lib/utils";
 
-type ProgressProps = React.ComponentPropsWithoutRef<
-  typeof ProgressPrimitive.Root
-> & {
+type ProgressProps = ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> & {
   value?: number;
 };
 
-export const Progress = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
+export const Progress = forwardRef<
+  ElementRef<typeof ProgressPrimitive.Root>,
   ProgressProps
 >(({ className, value = 0, ...props }, ref) => (
   <ProgressPrimitive.Root


### PR DESCRIPTION
## 📝작업 내용

> 홈화면에 뜨는 카드 컴포넌트 생성
> 홈화면에 뜨는 적금 컴포넌트 생성

## 스크린샷 (선택)
<img width="394" alt="스크린샷 2025-06-16 오전 11 31 08" src="https://github.com/user-attachments/assets/02ee89c7-d526-4c27-9fa8-7a9bdd027f21" />
