### PR TITLE
Feat: 홈 내 하나올림- 편지, 포인트 상세 컴포넌트 생성

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,5 @@
 import Profile from "@/components/home/Profile";
 
 export default function Page() {
-  return (
-    <>
-      <Profile endDate={""} />
-    </>
-  );
+  return <>홈</>;
 }

--- a/components/home/Card.tsx
+++ b/components/home/Card.tsx
@@ -36,7 +36,6 @@ export default function Card() {
             align="center"
             padding="py-0"
             onClick={handleClick}
-            className="flex items-center justify-center h-[23px]"
           />
         </div>
       </div>

--- a/components/home/Card.tsx
+++ b/components/home/Card.tsx
@@ -26,7 +26,7 @@ export default function Card() {
           123,000원
         </Txt>
 
-        <div className="mt-5 w-[80px]">
+        <div className="mt-3">
           <PrimaryButton
             title="보내기"
             color="green"
@@ -35,6 +35,7 @@ export default function Card() {
             weight="medium"
             align="center"
             padding="py-0"
+            className="w-[80px] h-[23px]"
             onClick={handleClick}
           />
         </div>

--- a/components/home/Card.tsx
+++ b/components/home/Card.tsx
@@ -13,7 +13,7 @@ export default function Card() {
   };
 
   return (
-    <div className="flex items-center justify-between px-6 py-3 bg-green-5f2 border-[1px] border-green-9e7  rounded-[20px] w-max h-[150px] overflow-hidden gap-3">
+    <div className="flex items-center justify-between pl-[23px] pr-[25px] py-[19px] bg-green-5f2 border-[1px] border-green-9e7 rounded-[20px] w-max h-[150px] overflow-hidden">
       {/* 카드 정보 */}
       <div className="flex flex-col items-start">
         <Txt size={16} weight="bold" className="text-gray-353">
@@ -42,7 +42,7 @@ export default function Card() {
       </div>
 
       {/* 카드 이미지 */}
-      <div className="flex-shrink-0 relative w-[80px] h-[130px] ml-9">
+      <div className="flex-shrink-0 relative ml-[42px] w-[80px] h-[130px]">
         <Image
           src="/images/ic-hanacard.svg"
           alt="하나 나라사랑카드"

--- a/components/home/Card.tsx
+++ b/components/home/Card.tsx
@@ -1,3 +1,56 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import Txt from "@/components/atoms/Text";
+import PrimaryButton from "../atoms/PrimaryButton";
+
 export default function Card() {
-  return <>하나 나라사랑카드</>;
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push("/splash");
+  };
+
+  return (
+    <div className="flex items-center justify-between px-6 py-3 bg-green-5f2 border-[1px] border-green-9e7  rounded-[20px] w-max h-[150px] overflow-hidden gap-3">
+      {/* 카드 정보 */}
+      <div className="flex flex-col items-start">
+        <Txt size={16} weight="bold" className="text-gray-353">
+          하나 나라사랑카드(체크)
+        </Txt>
+        <Txt size={12} weight="bold" className="text-blue-9a0">
+          입출금 424-912949-15293
+        </Txt>
+        <Txt size={16} weight="bold" className="text-gray-900">
+          123,000원
+        </Txt>
+
+        <div className="mt-5 w-[80px]">
+          <PrimaryButton
+            title="보내기"
+            color="green"
+            rounded="sm"
+            textSize={12}
+            weight="medium"
+            align="center"
+            padding="py-0"
+            onClick={handleClick}
+            className="flex items-center justify-center h-[23px]"
+          />
+        </div>
+      </div>
+
+      {/* 카드 이미지 */}
+      <div className="flex-shrink-0 relative w-[80px] h-[130px] ml-9">
+        <Image
+          src="/images/ic-hanacard.svg"
+          alt="하나 나라사랑카드"
+          fill
+          className="object-contain"
+          priority
+        />
+      </div>
+    </div>
+  );
 }

--- a/components/home/Olim.tsx
+++ b/components/home/Olim.tsx
@@ -1,3 +1,0 @@
-export default function Olim() {
-  return <>하나올림</>;
-}

--- a/components/home/Profile.tsx
+++ b/components/home/Profile.tsx
@@ -61,7 +61,7 @@ export default function ProfileBanner({ userName, startDate, endDate }: Props) {
 
         {/* 진행 바 + 전역일 디데이 */}
         <div className="mt-[4px]">
-          <Progress value={progressPercent} />
+          <Progress variant="green" />
           <div className="flex items-baseline gap-[2px] mt-[4px]">
             <Txt size={12} weight="cm" className="text-white">
               전역까지

--- a/components/home/Profile.tsx
+++ b/components/home/Profile.tsx
@@ -5,9 +5,9 @@ import Txt from "@/components/atoms/Text";
 import { Progress } from "@/components/ui/progress";
 
 type Props = {
-  endDate: string;
+  endDate: Date;
   userName?: string;
-  startDate?: string;
+  startDate?: Date;
 };
 
 export default function ProfileBanner({ userName, startDate, endDate }: Props) {

--- a/components/home/Savings.tsx
+++ b/components/home/Savings.tsx
@@ -1,3 +1,69 @@
+"use client";
+
+import Image from "next/image";
+import Txt from "@/components/atoms/Text";
+
 export default function Savings() {
-  return <>하나 장병내일준비 적금</>;
+  return (
+    <div
+      className="flex flex-col justify-between px-6 py-4 bg-white-fff rounded-[20px] w-max h-[153px] shadow-sm"
+      style={{ boxShadow: "0px 0px 5px 0px rgba(0, 0, 0, 0.15)" }}
+    >
+      {/* 적금 제목, 금액, 이미지 */}
+      <div className="flex justify-between w-full">
+        <div className="flex flex-col items-start gap-1">
+          <Txt size={16} weight="bold" className="text-gray-939">
+            하나 장병내일준비 적금
+          </Txt>
+          <Txt size={16} weight="bold" className="text-gray-939">
+            2,109,762원
+          </Txt>
+        </div>
+        <div className="flex-shrink-0 relative w-[80px] h-[60px] ml-15">
+          <Image
+            src="/images/ic-bankbook.svg"
+            alt="적금 통장"
+            fill
+            className="object-contain"
+            priority
+          />
+        </div>
+      </div>
+
+      {/* 조건 달성 여부 */}
+      <div className="flex flex-col gap-1 mt-2 w-full">
+        <div className="flex items-center w-full">
+          <div className="flex items-center justify-center w-[50px] h-[20px] bg-green-49d rounded-[10px] mr-2">
+            <Txt size={12} weight="medium" className="text-white-2f2">
+              달성
+            </Txt>
+          </div>
+          <Txt size={12} weight="medium" className="text-gray-939">
+            주택청약종합저축
+          </Txt>
+          <div className="ml-auto">
+            <Txt size={10} weight="medium" className="text-gray-939">
+              연 0.50%
+            </Txt>
+          </div>
+        </div>
+
+        <div className="flex items-center w-full">
+          <div className="flex items-center justify-center w-[50px] h-[20px] bg-white-2f2 rounded-[10px] mr-2">
+            <Txt size={12} weight="medium" className="text-green-49d">
+              미달성
+            </Txt>
+          </div>
+          <Txt size={12} weight="medium" className="text-gray-939">
+            하나카드결제
+          </Txt>
+          <div className="ml-auto">
+            <Txt size={10} weight="medium" className="text-gray-939">
+              연 0.70%
+            </Txt>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/components/home/Savings.tsx
+++ b/components/home/Savings.tsx
@@ -20,7 +20,7 @@ export default function Savings({ savingBalance }: Props) {
             {savingBalance.toLocaleString()}원
           </Txt>
         </div>
-        <div className="flex-shrink-0 relative w-[80px] h-[60px] ml-[57px]">
+        <div className="flex-shrink-0 relative pl-[57px] pr-[23px] h-[60px] ml-[57px]">
           <Image
             src="/images/ic-bankbook.svg"
             alt="적금 통장"
@@ -34,7 +34,7 @@ export default function Savings({ savingBalance }: Props) {
       {/* 조건 달성 여부 */}
       <div className="flex flex-col gap-1 mt-2 w-full">
         <div className="flex items-center w-full">
-          <div className="flex items-center justify-center w-[50px] h-[20px] bg-green-49d rounded-[10px] mr-2">
+          <div className="flex items-center justify-center px-[14px] h-[20px] bg-green-49d rounded-[10px] mr-2">
             <Txt size={12} weight="medium" className="text-white-2f2">
               달성
             </Txt>
@@ -50,7 +50,7 @@ export default function Savings({ savingBalance }: Props) {
         </div>
 
         <div className="flex items-center w-full">
-          <div className="flex items-center justify-center w-[50px] h-[20px] bg-white-2f2 rounded-[10px] mr-2">
+          <div className="flex items-center justify-center px-[9px] h-[20px] bg-white-2f2 rounded-[10px] mr-2">
             <Txt size={12} weight="medium" className="text-green-49d">
               미달성
             </Txt>

--- a/components/home/Savings.tsx
+++ b/components/home/Savings.tsx
@@ -3,10 +3,14 @@
 import Image from "next/image";
 import Txt from "@/components/atoms/Text";
 
-export default function Savings() {
+type Props = {
+  savingBalance: number;
+};
+
+export default function Savings({ savingBalance }: Props) {
   return (
     <div
-      className="flex flex-col justify-between px-6 py-4 bg-white-fff rounded-[20px] w-max h-[153px] shadow-sm"
+      className="flex flex-col justify-between px-6 py-4 bg-white-fff rounded-[20px] w-max h-[153px]"
       style={{ boxShadow: "0px 0px 5px 0px rgba(0, 0, 0, 0.15)" }}
     >
       {/* 적금 제목, 금액, 이미지 */}
@@ -16,10 +20,10 @@ export default function Savings() {
             하나 장병내일준비 적금
           </Txt>
           <Txt size={16} weight="bold" className="text-gray-939">
-            2,109,762원
+            {savingBalance.toLocaleString()}원
           </Txt>
         </div>
-        <div className="flex-shrink-0 relative w-[80px] h-[60px] ml-15">
+        <div className="flex-shrink-0 relative w-[80px] h-[60px] ml-[57px]">
           <Image
             src="/images/ic-bankbook.svg"
             alt="적금 통장"

--- a/components/home/Savings.tsx
+++ b/components/home/Savings.tsx
@@ -9,17 +9,14 @@ type Props = {
 
 export default function Savings({ savingBalance }: Props) {
   return (
-    <div
-      className="flex flex-col justify-between px-6 py-4 bg-white-fff rounded-[20px] w-max h-[153px]"
-      style={{ boxShadow: "0px 0px 5px 0px rgba(0, 0, 0, 0.15)" }}
-    >
+    <div className="flex flex-col justify-between px-6 py-4 bg-white-fff rounded-[20px] w-max h-[153px] shadow-[0_0_5px_rgba(0,0,0,0.15)]">
       {/* 적금 제목, 금액, 이미지 */}
       <div className="flex justify-between w-full">
         <div className="flex flex-col items-start gap-1">
-          <Txt size={16} weight="bold" className="text-gray-939">
+          <Txt size={16} weight="bold">
             하나 장병내일준비 적금
           </Txt>
-          <Txt size={16} weight="bold" className="text-gray-939">
+          <Txt size={16} weight="bold">
             {savingBalance.toLocaleString()}원
           </Txt>
         </div>
@@ -42,11 +39,11 @@ export default function Savings({ savingBalance }: Props) {
               달성
             </Txt>
           </div>
-          <Txt size={12} weight="medium" className="text-gray-939">
+          <Txt size={12} weight="medium">
             주택청약종합저축
           </Txt>
           <div className="ml-auto">
-            <Txt size={10} weight="medium" className="text-gray-939">
+            <Txt size={10} weight="medium">
               연 0.50%
             </Txt>
           </div>
@@ -58,11 +55,11 @@ export default function Savings({ savingBalance }: Props) {
               미달성
             </Txt>
           </div>
-          <Txt size={12} weight="medium" className="text-gray-939">
+          <Txt size={12} weight="medium">
             하나카드결제
           </Txt>
           <div className="ml-auto">
-            <Txt size={10} weight="medium" className="text-gray-939">
+            <Txt size={10} weight="medium">
               연 0.70%
             </Txt>
           </div>

--- a/components/home/Savings.tsx
+++ b/components/home/Savings.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export default function Savings({ savingBalance }: Props) {
   return (
-    <div className="flex flex-col justify-between px-6 py-4 bg-white-fff rounded-[20px] w-max h-[153px] shadow-[0_0_5px_rgba(0,0,0,0.15)]">
+    <div className="flex flex-col justify-between px-[23px] py-[19px] bg-white-fff rounded-[20px] w-max h-[153px] shadow-[0_0_5px_rgba(0,0,0,0.15)]">
       {/* 적금 제목, 금액, 이미지 */}
       <div className="flex justify-between w-full">
         <div className="flex flex-col items-start gap-1">
@@ -20,7 +20,7 @@ export default function Savings({ savingBalance }: Props) {
             {savingBalance.toLocaleString()}원
           </Txt>
         </div>
-        <div className="flex-shrink-0 relative pl-[57px] pr-[23px] h-[60px] ml-[57px]">
+        <div className="flex-shrink-0 relative ml-[57px] w-[80px] h-[60px]">
           <Image
             src="/images/ic-bankbook.svg"
             alt="적금 통장"
@@ -32,7 +32,7 @@ export default function Savings({ savingBalance }: Props) {
       </div>
 
       {/* 조건 달성 여부 */}
-      <div className="flex flex-col gap-1 mt-2 w-full">
+      <div className="flex flex-col gap-1 mt-2">
         <div className="flex items-center w-full">
           <div className="flex items-center justify-center px-[14px] h-[20px] bg-green-49d rounded-[10px] mr-2">
             <Txt size={12} weight="medium" className="text-white-2f2">

--- a/components/home/hanaolim/Letter.tsx
+++ b/components/home/hanaolim/Letter.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Image from "next/image";
+import Txt from "@/components/atoms/Text";
+
+type Props = {
+  receivedTotal: string;
+};
+
+export default function Letter({ receivedTotal }: Props) {
+  return (
+    <div className="flex items-center px-4 py-2 w-fit h-[61px] rounded-[15px] bg-blue-0f5 border border-blue-af0">
+      <Txt size={14} weight="medium" className="text-gray-939">
+        받은 편지
+      </Txt>
+      <Txt size={14} weight="heavy" className="text-green-49d ml-[24px]">
+        {receivedTotal}
+      </Txt>
+      <Image
+        src="/images/ic-letter.svg"
+        alt="편지 아이콘"
+        width={33}
+        height={33}
+        className="ml-[13px]"
+      />
+    </div>
+  );
+}

--- a/components/home/hanaolim/Letter.tsx
+++ b/components/home/hanaolim/Letter.tsx
@@ -1,20 +1,21 @@
 "use client";
 
 import Image from "next/image";
+import { ReceivedTotalLetter } from "@/types/letters";
 import Txt from "@/components/atoms/Text";
 
 type Props = {
-  receivedTotal: string;
+  receivedTotalLetter: ReceivedTotalLetter;
 };
 
-export default function Letter({ receivedTotal }: Props) {
+export default function Letter({ receivedTotalLetter }: Props) {
   return (
     <div className="flex items-center px-4 py-2 w-fit h-[61px] rounded-[15px] bg-blue-0f5 border border-blue-af0">
       <Txt size={14} weight="medium" className="text-gray-939">
         받은 편지
       </Txt>
       <Txt size={14} weight="heavy" className="text-green-49d ml-[24px]">
-        {receivedTotal}
+        {receivedTotalLetter.unreadLetter}/{receivedTotalLetter.totalLetter}
       </Txt>
       <Image
         src="/images/ic-letter.svg"

--- a/components/home/hanaolim/Olim.tsx
+++ b/components/home/hanaolim/Olim.tsx
@@ -1,0 +1,14 @@
+import Letter from "./Letter";
+import Point from "./Point";
+
+const receivedTotalLetter = { unreadLetter: 8, totalLetter: 32 };
+const pointAccrue = { myStamp: 2, totalStamp: 10 };
+
+export default function Olim() {
+  return (
+    <>
+      <Letter receivedTotalLetter={receivedTotalLetter} />
+      <Point pointAccrue={pointAccrue} />
+    </>
+  );
+}

--- a/components/home/hanaolim/Point.tsx
+++ b/components/home/hanaolim/Point.tsx
@@ -2,9 +2,11 @@
 
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import { PointAccrue } from "@/types/points";
 import Txt from "@/components/atoms/Text";
 import { Progress } from "@/components/ui/progress";
+import PointRuleTooltip from "./PointRuleTooltip";
 
 type Props = {
   pointAccrue: PointAccrue;
@@ -12,19 +14,22 @@ type Props = {
 
 export default function Point({ pointAccrue }: Props) {
   const router = useRouter();
+  const [showTooltip, setShowTooltip] = useState(false);
 
   const handleClick = () => {
     router.push("/pointHistory");
   };
 
+  const toggleTooltip = () => setShowTooltip((prev) => !prev);
+
   return (
-    <div className="w-fit px-4 py-3 rounded-[15px] bg-yellow-4d8 border border-yellow-9af flex flex-col gap-[6px]">
+    <div className="relative w-fit px-4 py-3 rounded-[15px] bg-yellow-4d8 border border-yellow-9af flex flex-col gap-[6px]">
       <div className="flex items-center w-full">
         <Txt size={14} weight="medium" className="text-gray-939">
           포인트 적립까지
         </Txt>
 
-        <div className="flex items-center">
+        <div className="flex items-center relative">
           <Txt size={14} weight="heavy" className="text-yellow-32b ml-[17px]">
             {pointAccrue.myStamp}/{pointAccrue.totalStamp}
           </Txt>
@@ -40,17 +45,19 @@ export default function Point({ pointAccrue }: Props) {
             alt="도움말 아이콘"
             width={15}
             height={15}
-            className="ml-[60px]"
+            className="ml-[60px] cursor-pointer"
+            onClick={toggleTooltip}
           />
+          {showTooltip && (
+            <div className="absolute top-full left-1/2 transform -translate-x-1/2 mt-3 z-10">
+              <PointRuleTooltip />
+            </div>
+          )}
         </div>
       </div>
 
-      {/* 포인트 적립 진행률 바 */}
-      <div>
-        <Progress variant="yellow" />
-      </div>
+      <Progress variant="yellow" />
 
-      {/* 포인트 내역 조회로 이동 */}
       <Txt
         size={12}
         weight="medium"

--- a/components/home/hanaolim/Point.tsx
+++ b/components/home/hanaolim/Point.tsx
@@ -1,3 +1,64 @@
-export default function Point() {
-  return <>포인트 적립까지</>;
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { PointAccrue } from "@/types/points";
+import Txt from "@/components/atoms/Text";
+import { Progress } from "@/components/ui/progress";
+
+type Props = {
+  pointAccrue: PointAccrue;
+};
+
+export default function Point({ pointAccrue }: Props) {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push("/pointHistory");
+  };
+
+  return (
+    <div className="w-fit px-4 py-3 rounded-[15px] bg-yellow-4d8 border border-yellow-9af flex flex-col gap-[6px]">
+      <div className="flex items-center w-full">
+        <Txt size={14} weight="medium" className="text-gray-939">
+          포인트 적립까지
+        </Txt>
+
+        <div className="flex items-center">
+          <Txt size={14} weight="heavy" className="text-yellow-32b ml-[17px]">
+            {pointAccrue.myStamp}/{pointAccrue.totalStamp}
+          </Txt>
+          <Image
+            src="/images/ic-coin.svg"
+            alt="코인 아이콘"
+            width={25}
+            height={25}
+            className="ml-[9px]"
+          />
+          <Image
+            src="/images/ic-question.svg"
+            alt="도움말 아이콘"
+            width={15}
+            height={15}
+            className="ml-[60px]"
+          />
+        </div>
+      </div>
+
+      {/* 포인트 적립 진행률 바 */}
+      <div>
+        <Progress variant="yellow" />
+      </div>
+
+      {/* 포인트 내역 조회로 이동 */}
+      <Txt
+        size={12}
+        weight="medium"
+        className="text-gray-353 underline self-end cursor-pointer"
+        onClick={handleClick}
+      >
+        포인트 내역보기
+      </Txt>
+    </div>
+  );
 }

--- a/components/home/hanaolim/Point.tsx
+++ b/components/home/hanaolim/Point.tsx
@@ -1,0 +1,3 @@
+export default function Point() {
+  return <>포인트 적립까지</>;
+}

--- a/components/home/hanaolim/PointRuleTooltip.tsx
+++ b/components/home/hanaolim/PointRuleTooltip.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import Txt from "@/components/atoms/Text";
+
+export default function PointRuleTooltip() {
+  return (
+    <div className="relative flex flex-col items-end">
+      <div className="absolute -top-3 right-11.5">
+        {/* 말풍선 꼬리 */}
+        <div className="w-0 h-0 border-x-10 border-x-transparent border-b-[15px] border-b-green-49d z-20"></div>
+        <div className="absolute w-0 h-0 border-x-10 border-x-transparent border-b-[15px] border-b-white -mt-3.5 z-50"></div>
+      </div>
+      {/* 말풍선 본체 */}
+      <div className="w-max h-[35px] bg-white border-[0.5px] border-green-49d rounded-[10px] px-4 flex items-center z-30 shadow">
+        <Txt size={12} weight="cm" className="text-green-49d">
+          동일 회원의 편지는 하루에 최대 1개만 반영됩니다.
+        </Txt>
+      </div>
+    </div>
+  );
+}

--- a/components/home/index.ts
+++ b/components/home/index.ts
@@ -1,4 +1,6 @@
-export { default as Card } from "./Card";
-export { default as Olim } from "./Olim";
 export { default as Profile } from "./Profile";
+export { default as Olim } from "./hanaolim/Olim";
+export { default as Letter } from "./hanaolim/Letter";
+export { default as Point } from "./hanaolim/Point";
+export { default as Card } from "./Card";
 export { default as Savings } from "./Savings";

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -7,26 +7,33 @@ import { cn } from "@/lib/utils";
 
 type ProgressProps = ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> & {
   value?: number;
+  variant?: "green" | "yellow";
 };
 
 export const Progress = forwardRef<
   ElementRef<typeof ProgressPrimitive.Root>,
   ProgressProps
->(({ className, value = 0, ...props }, ref) => (
-  <ProgressPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative h-[6px] w-[208px] rounded-full bg-green-fa7",
-      className
-    )}
-    {...props}
-    value={value}
-  >
-    <ProgressPrimitive.Indicator
-      className="absolute h-full rounded-full bg-green-a3b transition-all"
-      style={{ width: `${value}%` }}
-    />
-  </ProgressPrimitive.Root>
-));
+>(({ className, value = 0, variant = "green", ...props }, ref) => {
+  const rootBg = variant === "green" ? "bg-green-fa7" : "bg-white-fff";
+  const indicatorBg = variant === "green" ? "bg-green-a3b" : "bg-yellow-32b";
+  const width = variant === "green" ? "w-[208px]" : "w-[258px]";
+
+  return (
+    <ProgressPrimitive.Root
+      ref={ref}
+      className={cn("relative h-[8px] rounded-full", rootBg, width, className)}
+      {...props}
+      value={value}
+    >
+      <ProgressPrimitive.Indicator
+        className={cn(
+          "absolute h-full rounded-full transition-all",
+          indicatorBg
+        )}
+        style={{ width: `${value}%` }}
+      />
+    </ProgressPrimitive.Root>
+  );
+});
 
 Progress.displayName = ProgressPrimitive.Root.displayName;

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -2,16 +2,15 @@
 
 import * as ProgressPrimitive from "@radix-ui/react-progress";
 import * as React from "react";
+import { ComponentPropsWithoutRef, forwardRef, ElementRef } from "react";
 import { cn } from "@/lib/utils";
 
-type ProgressProps = React.ComponentPropsWithoutRef<
-  typeof ProgressPrimitive.Root
-> & {
+type ProgressProps = ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> & {
   value?: number;
 };
 
-export const Progress = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
+export const Progress = forwardRef<
+  ElementRef<typeof ProgressPrimitive.Root>,
   ProgressProps
 >(({ className, value = 0, ...props }, ref) => (
   <ProgressPrimitive.Root

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -6,7 +6,7 @@ import { ComponentPropsWithoutRef, forwardRef, ElementRef } from "react";
 import { cn } from "@/lib/utils";
 
 type ProgressProps = ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> & {
-  value?: number;
+  value: number;
   variant?: "green" | "yellow";
 };
 

--- a/types/letters.ts
+++ b/types/letters.ts
@@ -3,3 +3,5 @@ export type uploadedFileType = {
   url: string;
   type: "image" | "video";
 };
+
+export type ReceivedTotalLetter = { unreadLetter: number; totalLetter: number };

--- a/types/points.ts
+++ b/types/points.ts
@@ -1,0 +1,1 @@
+export type PointAccrue = { myStamp: number; totalStamp: number };


### PR DESCRIPTION
## 📝작업 내용

> 받은편지 컴포넌트 생성
> 포인트적립 컴포넌트 생성
> 포인트적립 내 말풍선 tooltip 생성
> 홈 내 프로필, 카드, 적금 컴포넌트 width를 padding으로 변경
> progress에 두개 타입으로 변경하여 프로필과 포인트 적립에서 바 사용

## 스크린샷 (선택)
<img width="372" alt="스크린샷 2025-06-16 오후 5 41 02" src="https://github.com/user-attachments/assets/69e9e204-a6ff-4743-861b-2029cd48db93" />
<img width="342" alt="스크린샷 2025-06-16 오후 5 42 45" src="https://github.com/user-attachments/assets/f0768ea6-775a-4a94-abd5-8a6a6c88f910" />
