### PR TITLE
Refactor: 홈 내 각 컴포넌트 클릭 시 이동되는 경로 수정

### DIFF
--- a/components/home/Card.tsx
+++ b/components/home/Card.tsx
@@ -12,7 +12,10 @@ export default function Card() {
   };
 
   return (
-    <div className="flex items-center justify-between w-full px-[23px] py-[19px] bg-green-5f2 border-[1px] border-green-9e7 rounded-[20px] h-[150px] overflow-hidden">
+    <div
+      onClick={handleSendClick}
+      className="flex items-center justify-between w-full px-[23px] py-[19px] bg-green-5f2 border-[1px] border-green-9e7 rounded-[20px] h-[150px] overflow-hidden cursor-pointer"
+    >
       {/* 카드 정보 */}
       <div className="flex flex-col items-start">
         <Txt size={16} weight="bold" className="text-gray-353">
@@ -35,7 +38,6 @@ export default function Card() {
             align="center"
             padding="py-0"
             className="w-[80px] h-[23px]"
-            onClick={handleSendClick}
           />
         </div>
       </div>

--- a/components/home/Olim.tsx
+++ b/components/home/Olim.tsx
@@ -13,7 +13,10 @@ export default function Olim() {
   const router = useRouter();
 
   return (
-    <div className="flex flex-col justify-between pl-[26px] py-[27px] pr-[22px] bg-white-fff rounded-[20px] shadow-[0_0_5px_rgba(0,0,0,0.15)]">
+    <div
+      onClick={() => router.push("/cabinet/Cabinet")}
+      className="flex flex-col justify-between pl-[26px] py-[27px] pr-[22px] bg-white-fff rounded-[20px] shadow-[0_0_5px_rgba(0,0,0,0.15)] cursor-pointer"
+    >
       <div className="flex justify-between w-full">
         <div className="flex flex-col items-start flex-shrink">
           <Txt size={22} weight="bold" className="text-green-49d mb-1">

--- a/components/home/Savings.tsx
+++ b/components/home/Savings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import Txt from "@/components/atoms/Text";
 
 type Props = {
@@ -8,8 +9,17 @@ type Props = {
 };
 
 export default function Savings({ savingBalance }: Props) {
+  const router = useRouter();
+
+  const handleSendClick = () => {
+    router.push("/hanaBank");
+  };
+
   return (
-    <div className="flex flex-col justify-between px-[23px] py-[19px] bg-white-fff rounded-[20px] w-full h-[153px] shadow-[0_0_5px_rgba(0,0,0,0.15)]">
+    <div
+      onClick={handleSendClick}
+      className="flex flex-col justify-between px-[23px] py-[19px] bg-white-fff rounded-[20px] w-full h-[153px] shadow-[0_0_5px_rgba(0,0,0,0.15)] cursor-pointer"
+    >
       {/* 적금 제목, 금액, 이미지 */}
       <div className="flex justify-between w-full">
         <div className="flex flex-col items-start gap-1">

--- a/components/home/hanaolim/Letter.tsx
+++ b/components/home/hanaolim/Letter.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { ReceivedTotalLetter } from "@/types/letters";
 import Txt from "@/components/atoms/Text";
 
@@ -9,8 +10,18 @@ type Props = {
 };
 
 export default function Letter({ receivedTotalLetter }: Props) {
+  const router = useRouter();
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    router.push("/letters");
+  };
+
   return (
-    <div className="flex justify-between items-center px-[17px] py-2 w-3/5 h-[61px] rounded-[15px] bg-blue-0f5 border border-blue-af0">
+    <div
+      onClick={handleClick}
+      className="flex justify-between items-center px-[17px] py-2 w-3/5 h-[61px] rounded-[15px] bg-blue-0f5 border border-blue-af0 cursor-pointer"
+    >
       <Txt size={14} weight="medium" className="text-gray-939">
         받은 편지
       </Txt>

--- a/components/home/hanaolim/Point.tsx
+++ b/components/home/hanaolim/Point.tsx
@@ -16,14 +16,20 @@ export default function Point({ pointAccrue }: Props) {
   const router = useRouter();
   const [showTooltip, setShowTooltip] = useState(false);
 
-  const handleClick = () => {
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
     router.push("/pointHistory");
   };
 
-  const toggleTooltip = () => setShowTooltip((prev) => !prev);
-
+  const toggleTooltip = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setShowTooltip((prev) => !prev);
+  };
   return (
-    <div className="relative w-full px-[17px] py-3 rounded-[15px] bg-yellow-4d8 border border-yellow-9af flex flex-col gap-[6px]">
+    <div
+      onClick={handleClick}
+      className="relative w-full px-[17px] py-3 rounded-[15px] bg-yellow-4d8 border border-yellow-9af flex flex-col gap-[6px] cursor-pointer"
+    >
       <div className="flex items-center justify-between w-full">
         <Txt size={14} weight="medium" className="text-gray-939">
           포인트 적립까지

--- a/components/home/hanaolim/Point.tsx
+++ b/components/home/hanaolim/Point.tsx
@@ -47,7 +47,7 @@ export default function Point({ pointAccrue }: Props) {
             onClick={toggleTooltip}
           />
           {showTooltip && (
-            <div className="absolute top-full right-0 mt-3 z-10">
+            <div className="absolute top-full -left-27.5 mt-3 z-10">
               <PointRuleTooltip />
             </div>
           )}


### PR DESCRIPTION
## 📝작업 내용

> 홈 내 각 컴포넌트 클릭 시 이동되는 경로 수정했습니다.

- 포인트 정책 툴팁 x좌표 위치 변경하여 올바른 위치에 뜨도록 수정
- 홈 내 적금/카드 컴포넌트 클릭 시 하나원큐 스플래시로 이동하도록 구현
- 홈 하나올림- 편지 컴포넌트 클릭 시 편지 보관함으로 이동하고록 수정
- 홈 하나올림- 포인트 컴포넌트 클릭 시 포인트 내역 페이지로 이동하도록 수정
- 홈 하나올림 전체 컴포넌트 클릭 시 나의 관물대로 이동하도록 수정