### PR TITLE
!HOTFIX: prop soldierId를 userId로 변경

### DIFF
--- a/app/cabinet/[soldierId]/page.tsx
+++ b/app/cabinet/[soldierId]/page.tsx
@@ -39,7 +39,7 @@ export default async function CabinetPage({ params }: Props) {
           <CabinetHeader isMyCabinet={isMyCabinet} soldierInfo={soldierInfo} />
           <FriendsList soldierId={+soldierId} />
           <StatusMessage isMyCabinet={isMyCabinet} soldierInfo={soldierInfo} />
-          <Cabinet isMyCabinet={isMyCabinet} soldierId={+soldierId} />
+          <Cabinet isMyCabinet={isMyCabinet} userId={+soldierInfo.userId} />
           {!isMyCabinet && <LetterMoneyButton soldierId={+soldierId} />}
         </div>
         <DropDownModal isNew={isNew} />

--- a/components/cabinet/Cabinet.tsx
+++ b/components/cabinet/Cabinet.tsx
@@ -13,10 +13,10 @@ import LetterModal from "../letters/LetterModal";
 
 type Props = {
   isMyCabinet: boolean;
-  soldierId: number;
+  userId: number;
 };
 
-export default function Cabinet({ isMyCabinet, soldierId }: Props) {
+export default function Cabinet({ isMyCabinet, userId }: Props) {
   const [currentPage, setCurrentPage] = useState(1);
 
   const [totalPage, setTotalPage] = useState(1);
@@ -34,13 +34,12 @@ export default function Cabinet({ isMyCabinet, soldierId }: Props) {
 
   useEffect(() => {
     (async () => {
-      const totalLettersCnt =
-        await getTotalReceivedNonReplyLettersCnt(soldierId);
+      const totalLettersCnt = await getTotalReceivedNonReplyLettersCnt(userId);
 
       setTotalPage(Math.ceil(totalLettersCnt / 7));
 
       const letters = await getNonReplyLettersByUserId(
-        soldierId,
+        userId,
         1,
         totalLettersCnt
       );
@@ -54,7 +53,7 @@ export default function Cabinet({ isMyCabinet, soldierId }: Props) {
   useEffect(() => {
     (async () => {
       const letters = await getNonReplyLettersByUserId(
-        soldierId,
+        userId,
         currentPage,
         totalPage
       );


### PR DESCRIPTION
## 📝작업 내용

관물대에서 잘못된 id를 넘겨서 해당 userId의 편지가 아니라 해당 soldierId의 편지를 렌더링하는 오류 수정
