### PR TITLE
Fix: Letter modal point

### DIFF
--- a/app/pointHistory/page.tsx
+++ b/app/pointHistory/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import EmptyState from "@/components/EmptyList";
 import PointItem from "@/components/PointItem";
 import { Txt } from "@/components/atoms";
@@ -24,19 +25,27 @@ export default async function PointHistoryPage() {
         {pointSum.toLocaleString()} 원
       </Txt>
       <div className="flex-1 flex flex-col bg-white-fff -m-4 pb-8">
-        <div>
-          {/* 잔액/내역 구분선 */}
-          <div className="h-[1px] bg-gray-530 mb-4 mt-7 mx-7" />
-        </div>
-        {/* 포인트 입금 내역 */}
+        {/* 구분선 - 포인트 입금 내역 */}
         {pointList.length > 0 ? (
-          pointList.map((item) => (
-            <PointItem key={`${item.pointId}`} item={item} />
-          ))
+          <>
+            <div className="h-[1px] bg-gray-530 mb-4 mt-7 mx-7" />
+            {pointList.map((item) => (
+              <PointItem key={`${item.pointId}`} item={item} />
+            ))}
+          </>
         ) : (
-          <EmptyState>
-            포인트 내역이 없어요 <br /> 편지를 읽고 포인트를 받아 보세요!
-          </EmptyState>
+          <div className="flex flex-col justify-center items-center gap-6">
+            <EmptyState>
+              포인트 내역이 없어요 <br /> 편지를 읽고 포인트를 받아 보세요!{" "}
+              <br />
+            </EmptyState>
+            <Link
+              href={`/cabinet/${soldierId}`}
+              className="bg-green-49d text-white-fff p-2 rounded-[8px] text-[14px]"
+            >
+              편지 읽으러 가기
+            </Link>
+          </div>
         )}
       </div>
       {/* TODO: 무한스크롤 - 데이터 가져오는 중 */}

--- a/components/EmptyList.tsx
+++ b/components/EmptyList.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 export default function EmptyState({ children }: Props) {
   return (
-    <div className="flex flex-col justify-center items-center">
+    <div className="flex flex-col justify-center items-center pt-32">
       <Image
         src={"/images/byeoldol-sad.svg"}
         width={150}

--- a/components/FriendManageList.tsx
+++ b/components/FriendManageList.tsx
@@ -89,7 +89,6 @@ export default function FriendManageList({ friends }: Props) {
         ))
       ) : (
         <EmptyState>
-          {" "}
           친구 목록이 비어있어요 <br /> 친구를 추가하고 편지를 주고받아요!
         </EmptyState>
       )}

--- a/components/letters/LetterModal.tsx
+++ b/components/letters/LetterModal.tsx
@@ -6,7 +6,7 @@ import { useSession } from "next-auth/react";
 import { MouseEventHandler, useEffect, useRef, useState } from "react";
 import { getLetterDetail } from "@/lib/actions/letter-actions";
 import { Letter } from "@/types/letters";
-import { Txt } from "../atoms";
+import { PrimaryButton, Txt } from "../atoms";
 import LetterView from "./LetterView";
 import PigSplash from "./PigSplash";
 
@@ -78,12 +78,6 @@ export default function LetterModal({ letterId, onHandleModal }: Props) {
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [onKeyDown]);
 
-  /* useEffect(() => {
-    setShowPoint(true);
-    const timeout = setTimeout(() => setShowPoint(false), 1400);
-    return () => clearTimeout(timeout);
-  }, []); */
-
   return (
     <div
       ref={overlay}
@@ -100,8 +94,8 @@ export default function LetterModal({ letterId, onHandleModal }: Props) {
         onClick={handleGoToDetail}
       >
         <div className="flex w-full justify-between">
-          <Txt size={18} weight="cm" className="text-green-49d">
-            TO. {letter?.receiverName}
+          <Txt size={18} weight="bold" className="text-green-49d">
+            {letter?.senderName}({letter?.nickname})
           </Txt>
           <Image
             src={"/icons/ic-x-in-circle.svg"}
@@ -120,11 +114,11 @@ export default function LetterModal({ letterId, onHandleModal }: Props) {
             timeStyle: "short",
           })}
         </Txt>
-        <Txt align="left" className="py-4">
+        <Txt align="left" size={16} className="py-4">
           {letter?.content}
         </Txt>
         {letter?.fileUrl && <LetterView fileUrl={letter.fileUrl} />}
-        <div className="flex w-full justify-between">
+        <div className="flex w-full justify-end">
           <Txt
             align="left"
             weight="bold"
@@ -135,9 +129,6 @@ export default function LetterModal({ letterId, onHandleModal }: Props) {
             }}
           >
             답장하러 가기
-          </Txt>
-          <Txt size={18} weight="cm" className="text-green-49d">
-            From. {letter?.senderName}
           </Txt>
         </div>
       </div>

--- a/components/letters/LetterModal.tsx
+++ b/components/letters/LetterModal.tsx
@@ -25,7 +25,7 @@ export default function LetterModal({ letterId, onHandleModal }: Props) {
   const overlay = useRef<HTMLDivElement>(null);
   const router = useRouter();
 
-  //6줄 넘어갈 땐 더보기로 처리
+  //120자 넘어가면 더보기로 처리
   const isLong = (letter?.content.length ?? 0) > MAX_LENGTH;
 
   const preview = isLong

--- a/components/letters/LetterModal.tsx
+++ b/components/letters/LetterModal.tsx
@@ -6,7 +6,7 @@ import { useSession } from "next-auth/react";
 import { MouseEventHandler, useEffect, useRef, useState } from "react";
 import { getLetterDetail } from "@/lib/actions/letter-actions";
 import { Letter } from "@/types/letters";
-import { PrimaryButton, Txt } from "../atoms";
+import { Txt } from "../atoms";
 import LetterView from "./LetterView";
 import PigSplash from "./PigSplash";
 
@@ -18,10 +18,19 @@ type Props = {
   onHandleModal: () => void;
 };
 
+const MAX_LENGTH = 120;
+
 export default function LetterModal({ letterId, onHandleModal }: Props) {
   const [letter, setLetter] = useState<Letter | null>(null);
   const overlay = useRef<HTMLDivElement>(null);
   const router = useRouter();
+
+  //6줄 넘어갈 땐 더보기로 처리
+  const isLong = (letter?.content.length ?? 0) > MAX_LENGTH;
+
+  const preview = isLong
+    ? letter?.content.slice(0, MAX_LENGTH)
+    : letter?.content;
 
   const { data } = useSession();
 
@@ -90,8 +99,7 @@ export default function LetterModal({ letterId, onHandleModal }: Props) {
       <div
         className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2
                      w-11/12 sm:w-[22rem] p-6 bg-white rounded-[10px]
-                    text-center flex flex-col cursor-pointer"
-        onClick={handleGoToDetail}
+                    text-center max-h-[66vh] flex flex-col cursor-pointer"
       >
         <div className="flex w-full justify-between">
           <Txt size={18} weight="bold" className="text-green-49d">
@@ -114,8 +122,13 @@ export default function LetterModal({ letterId, onHandleModal }: Props) {
             timeStyle: "short",
           })}
         </Txt>
-        <Txt align="left" size={16} className="py-4">
-          {letter?.content}
+        <Txt align="left" size={16} className="py-4" onClick={handleGoToDetail}>
+          {preview}{" "}
+          {isLong && (
+            <Txt size={16} className="text-gray-500">
+              ...더보기
+            </Txt>
+          )}
         </Txt>
         {letter?.fileUrl && <LetterView fileUrl={letter.fileUrl} />}
         <div className="flex w-full justify-end">

--- a/components/letters/LetterModal.tsx
+++ b/components/letters/LetterModal.tsx
@@ -143,7 +143,7 @@ export default function LetterModal({ letterId, onHandleModal }: Props) {
               handleGoReply();
             }}
           >
-            답장하러 가기
+            답장하기
           </Txt>
         </div>
       </div>

--- a/components/letters/LetterView.tsx
+++ b/components/letters/LetterView.tsx
@@ -7,23 +7,25 @@ type Props = {
 export default function LetterView({ fileUrl }: Props) {
   return (
     <div className="w-full bg-gray-200 flex items-center justify-center rounded-md mb-6">
-      {fileUrl.endsWith(".mp4") || fileUrl.endsWith(".webm") ? (
-        <video
-          src={fileUrl}
-          width={100}
-          height={120}
-          controls
-          className="rounded-md w-full h-auto object-contain"
-        />
-      ) : (
-        <Image
-          src={fileUrl}
-          alt="첨부 이미지"
-          width={100}
-          height={120}
-          className="rounded-md w-full h-full object-contain"
-        />
-      )}
+      <div className="w-[80%] max-h-[30vh]">
+        {fileUrl.endsWith(".mp4") || fileUrl.endsWith(".webm") ? (
+          <video
+            src={fileUrl}
+            width={100}
+            height={120}
+            controls
+            className="rounded-md w-full h-auto object-contain"
+          />
+        ) : (
+          <Image
+            src={fileUrl}
+            alt="첨부 이미지"
+            width={100}
+            height={120}
+            className="rounded-md w-full h-full object-contain"
+          />
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 📝작업 내용

* 글자 수가 많을 때 모달이 너무 길어지는 것 방지했습니다 (120자 제한 나머지는 더보기 처리)
* 아무것도 없는 상태일 때 뜨는 컴포넌트가 너무 위쪽인 것 같아서 pt로  아래쪽으로 내렸습니다 
* 포인트 내역에서 아무것도 없을 땐 구분선 안 뜨도록 처리했습니다 그리고 관물대로 이동할 수 있는 버튼(링크) 추가했습니다

## 💬리뷰 요구사항(선택)
 x 버튼 이외의 것 눌렀을 때 상세보기로 가는데, 너무 범위가 넓은 것 같아
 (x 하려다 실수 할 수 있다 생각함, 실제로 테스트하다 불편함 많이 느낌) 텍스트 구역만 상세 보기로 변경했는데 의견 주세요~~

