### PR TITLE
Fix: 편지 내용 길 때 사진 페이드처리

### DIFF
--- a/components/letters/LetterView.tsx
+++ b/components/letters/LetterView.tsx
@@ -7,26 +7,24 @@ type Props = {
 
 export default function LetterView({ fileUrl }: Props) {
   return (
-    <div className="w-full bg-gray-200 flex items-center justify-center rounded-md mb-6 overflow-auto">
-      <div className="w-[80%] max-h-[30vh]">
-        {isVideoFile(fileUrl) ? (
-          <video
-            src={fileUrl}
-            width={100}
-            height={120}
-            controls
-            className="rounded-md w-full h-auto object-contain"
-          />
-        ) : (
-          <Image
-            src={fileUrl}
-            alt="첨부 이미지"
-            width={100}
-            height={120}
-            className="rounded-md w-full h-full object-contain"
-          />
-        )}
-      </div>
+    <div className="w-full bg-white-fff flex items-center justify-center mb-6 z-20">
+      {isVideoFile(fileUrl) ? (
+        <video
+          src={fileUrl}
+          width={100}
+          height={120}
+          controls
+          className="rounded-md w-full h-auto object-contain"
+        />
+      ) : (
+        <Image
+          src={fileUrl}
+          alt="첨부 이미지"
+          width={100}
+          height={120}
+          className="rounded-md w-full h-full object-contain"
+        />
+      )}
     </div>
   );
 }

--- a/hooks/useScrollEdge.ts
+++ b/hooks/useScrollEdge.ts
@@ -11,7 +11,7 @@ export const useScrollEdges = <T extends HTMLDivElement>() => {
     const update = () => {
       const distanceFromBottom =
         el.scrollHeight - el.scrollTop - el.clientHeight;
-      setIsBottom(distanceFromBottom <= 60); //스크롤 내리면 페이드 사라짐 (500자 맞춰서 설정)
+      setIsBottom(distanceFromBottom <= 100); //스크롤 내리면 페이드 사라짐 (500자 맞춰서 설정)
     };
 
     //초기 값 감지


### PR DESCRIPTION
## 📝작업 내용

* 글 내용이 길 때 들어가는 페이드처리를 사진에는 안 들어가도록 고쳤습니다 

